### PR TITLE
Add upated isWin to patrick refactor branch

### DIFF
--- a/devlog.md
+++ b/devlog.md
@@ -123,3 +123,8 @@ a tic-tac-toe game that insults you at every turn. winning does not guarantee ex
 2023-09-08
 - 5m: On isWin/patrick-refactor branch, separate X and O win logic for horizontal win
 - 5m: Make X and O seperate if and elif statements
+- 10m: Update rest of elif statements
+- 5m: Add isWin() with sample board to run
+- 5m: Add test_suite()
+- 5m: Add more specific print strings to test_suit() by win condition
+- 5m: Fix bug in checkWin() for 'O's in horizontal win, bottom row

--- a/devlog.md
+++ b/devlog.md
@@ -122,3 +122,4 @@ a tic-tac-toe game that insults you at every turn. winning does not guarantee ex
 
 2023-09-08
 - 5m: On isWin/patrick-refactor branch, separate X and O win logic for horizontal win
+- 5m: Make X and O seperate if and elif statements

--- a/devlog.md
+++ b/devlog.md
@@ -119,3 +119,6 @@ a tic-tac-toe game that insults you at every turn. winning does not guarantee ex
 - 5m: Start writing PR for patrick-refactor branch
 - 25m: Complete writing PR for patrick-refactor branch
 - 15m: Add additional comments in TODOs
+
+2023-09-08
+- 5m: On isWin/patrick-refactor branch, separate X and O win logic for horizontal win

--- a/infrastructure_overview.md
+++ b/infrastructure_overview.md
@@ -129,6 +129,10 @@ def tic_tactless_toe():
     Switch players
         Boolean logic? eg x_player is 0, o_player is 1. Or is it x_player's turn? True, False. If x_player turn False, turn o_player's to True
     Win logic
+        board as array values
+            |0,0 |0,1  |0,2 |
+            |1,0 |1,1  |1,2 |
+            |2,0 |2,1  |2,2 |
         example of player x winning board
             c1,c2,c3
         r1 |x |  |o |

--- a/tic-tactless-toe.py
+++ b/tic-tactless-toe.py
@@ -81,6 +81,7 @@ def isWin(board):
         # game_status = 'win_game'
         print('Congratulations! You won!')
         isWin = True
+    # if (board[0][0] == 'O' and board[0][1] == 'O' and (board[0][2] == 'X') or (board[0][0] == 'X' and board[0][1] == 'O' and (board[0][2] == 'X')
     # middle row
     elif (board[1][0] == 'X' or 'O') and (board[1][1] == 'X' or 'O') and (board[1][2] == 'X' or 'O'):
         game_status = 'win_game'

--- a/tic-tactless-toe.py
+++ b/tic-tactless-toe.py
@@ -77,11 +77,14 @@ def isWin(board):
     # horizontal win condition (3 variations)
     # top row
     isWin = False
-    if (board[0][0] == 'X' or board[0][0] == 'O') and (board[0][1] == 'X' or board[0][1] == 'O') and (board[0][2] == 'X' or board[0][2] == 'O'):
+    if (board[0][0] == 'X') and (board[0][1] == 'X') and (board[0][2] == 'X'):
         # game_status = 'win_game'
         print('Congratulations! You won!')
         isWin = True
-    # if (board[0][0] == 'O' and board[0][1] == 'O' and (board[0][2] == 'X') or (board[0][0] == 'X' and board[0][1] == 'O' and (board[0][2] == 'X')
+    elif (board[0][0] == 'O') and (board[0][1] == 'O') and (board[0][2] == 'O'):
+        # game_status = 'win_game'
+        print('Congratulations! You won!')
+        isWin = True
     # middle row
     elif (board[1][0] == 'X' or 'O') and (board[1][1] == 'X' or 'O') and (board[1][2] == 'X' or 'O'):
         game_status = 'win_game'

--- a/tic-tactless-toe.py
+++ b/tic-tactless-toe.py
@@ -77,49 +77,45 @@ def isWin(board):
     # horizontal win condition (3 variations)
     # top row
     isWin = False
-    if (board[0][0] == 'X') and (board[0][1] == 'X') and (board[0][2] == 'X'):
+    if ((board[0][0] == 'X') and (board[0][1] == 'X') and (board[0][2] == 'X')) or ((board[0][0] == 'O') and (board[0][1] == 'O') and (board[0][2] == 'O')):
         # game_status = 'win_game'
-        print('Congratulations! You won!')
-        isWin = True
-    elif (board[0][0] == 'O') and (board[0][1] == 'O') and (board[0][2] == 'O'):
-        # game_status = 'win_game'
-        print('Congratulations! You won!')
+        print('Congratulations! You won! Horizontal win, top row.')
         isWin = True
     # middle row
-    elif (board[1][0] == 'X' or 'O') and (board[1][1] == 'X' or 'O') and (board[1][2] == 'X' or 'O'):
+    elif ((board[1][0] == 'X') and (board[1][1] == 'X') and (board[1][2] == 'X')) or ((board[1][0] == 'O') and (board[1][1] == 'O') and (board[1][2] == 'O')):
         game_status = 'win_game'
-        print('Congratulations! You won!')
+        print('Congratulations! You won! Horizontal win, middle row.')
         isWin = True
     # bottom row
-    elif (board[2][0] == 'X' or 'O') and (board[2][1] == 'X' or 'O') and (board[2][2] == 'X' or 'O'):
+    elif ((board[2][0] == 'X') and (board[2][1] == 'X') and (board[2][2] == 'X')) or ((board[2][0] == 'O') and (board[2][1] == 'O') and (board[2][2] == 'O')):
         game_status = 'win_game'
-        print('Congratulations! You won!') # in future, replace with quotes
+        print('Congratulations! You won! Horizontal win, bottom row.')
     # vertical win condition (3 variations)
     # left column
-    elif (board[0][1] == 'X' or 'O') and (board[1][1] == 'X' or 'O') and (board[2][1] == 'X' or 'O'):
+    elif ((board[0][0] == 'X') and (board[1][0] == 'X') and (board[2][0] == 'X')) or ((board[0][0] == 'O') and (board[1][0] == 'O') and (board[2][0] == 'O')):
         game_status = 'win_game'
-        print('Congratulations! You won!')
+        print('Congratulations! You won! Vertical win, left column.')
         isWin = True
     # middle column
-    elif (board[0][1] == 'X' or 'O') and (board[1][1] == 'X' or 'O') and (board[2][1] == 'X' or 'O'):
+    elif ((board[0][1] == 'X') and (board[1][1] == 'X') and (board[2][1] == 'X')) or ((board[0][1] == 'O') and (board[1][1] == 'O') and (board[2][1] == 'O')):
         game_status = 'win_game'
-        print('Congratulations! You won!')
+        print('Congratulations! You won! Vertical win, middle column.')
         isWin = True
     # right column
-    elif (board[0][2] == 'X' or 'O') and (board[1][2] == 'X' or 'O') and (board[2][2] == 'X' or 'O'):
+    elif ((board[0][2] == 'X') and (board[1][2] == 'X') and (board[2][2] == 'X')) or ((board[0][2] == 'O') and (board[1][2] == 'O') and (board[2][2] == 'O')):
         game_status = 'win_game'
-        print('Congratulations! You won!')
+        print('Congratulations! You won! Vertical win, right column.')
         isWin = True
     # diagonal win conditions (2 variations)
     # left-to-right diagonal
-    elif (board[0][0] == 'X' or 'O') and (board[1][1] == 'X' or 'O') and (board[2][2] == 'X' or 'O'):
+    elif ((board[0][0] == 'X') and (board[1][1] == 'X') and (board[2][2] == 'X')) or (board[0][0] == 'O') and (board[1][1] == 'O') and (board[2][2] == 'O'):
         game_status = 'win_game'
-        print('Congratulations! You won!')
+        print('Congratulations! You won! Diagonal win, left-to-right.')
         isWin = True 
     # right-to-left diagonal
-    elif (board[0][2] == 'X' or 'O') and (board[1][1] == 'X' or 'O') and (board[0][0] == 'X' or 'O'):
+    elif ((board[0][2] == 'X') and (board[1][1] == 'X') and (board[2][0] == 'X')) or (board[0][2] == 'O') and (board[1][1] == 'O') and (board[2][0] == 'O'):
         game_status = 'win_game'
-        print('Congratulations! You won!')
+        print('Congratulations! You won! Diagonal win, right-to-left')
         isWin = True 
     return isWin
 
@@ -201,7 +197,36 @@ def quit_game():
     print('You have chosen to quit the game. The game will now quit.')
     quit()
 
-start_game()
+def test_suite():
+    # X win
+    # horizontal win
+    isWin([["X","X","X"], ["","", ""], ["","",""]])
+    isWin([["","",""], ["X","X", "X"], ["","",""]])
+    isWin([["","",""], ["","", ""], ["X","X","X"]])    
+    # vertical win
+    isWin([["X","",""], ["X","", ""], ["X","",""]])
+    isWin([["","X",""], ["","X", ""], ["","X",""]])
+    isWin([["","","X"], ["","", "X"], ["","","X"]])
+    # diagonal win
+    isWin([["X","",""], ["","X", ""], ["","","X"]])
+    isWin([["","","X"], ["","X", ""], ["X","",""]])
+    # O win
+    # horizontal win
+    isWin([["O","O","O"], ["","", ""], ["","",""]])
+    isWin([["","",""], ["O","O","O"], ["","",""]])
+    isWin([["","",""], ["","", ""], ["O","O","O"]])    
+    # vertical win
+    isWin([["O","",""], ["O","", ""], ["O","",""]])
+    isWin([["","O",""], ["","O", ""], ["","O",""]])
+    isWin([["","","O"], ["","", "O"], ["","","O"]])
+    # diagonal win
+    isWin([["O","",""], ["","O", ""], ["","","O"]])
+    isWin([["","","O"], ["","O", ""], ["O","",""]])
+
+# start_game()
+# isWin([["X","",""], ["X","", ""], ["X","",""]]) 
+test_suite()
+
 
 """
   - start()
@@ -303,13 +328,13 @@ def tic_tactless_toe():
             0 |x |  |  |
             1 |  |x |  |
             2 |  |  |x |
-            if (board[0][0] = 'X' or 'O') and (board[1][1] = 'X' or 'O') and (board[2][2] = 'X' or 'O') ...
+            if (board[0][0] = 'X') and (board[1][1] = 'X') and (board[2][2] = 'X') ...
             veritcal win condition 2
                0, 1, 2
             0 |  |o |  |
             1 |  |o |  |
             2 |  |o |  |
-            if (board[0][1] = 'X' or 'O') and (board[1][1] = 'X' or 'O') and (board[2][1] = 'X' or 'O') ...
+            if (board[0][1] = 'X') and (board[1][1] = 'X') and (board[2][1] = 'X') ...
     Draw logic
         When all sections of board are filled up without any win conditions
         Filled up: If all section is not " ". Check for all using for loop?

--- a/tic-tactless-toe.py
+++ b/tic-tactless-toe.py
@@ -1,9 +1,7 @@
 # Overarching program
 # TODO: For Mars to do, translation dictionary of row, column to array values
 # TODO make player_move be an array
-# TODO Fix logic in isWin
 # board = [[" "," ", " "], [" "," ", " "], [" "," ", " "]] # final board
-# board = [["X","X", "X"], ["middle left","middle middle", "middle right"], ["bottom left","bottom middle", "bottom right"]]  # testing board, not final values
 game_status = "start_game" # not sure what to start game with. may want to change from variable to dictionary?
 
 def print_board(board):


### PR DESCRIPTION
 Solves #5 

**Problem**
- Row doesn't need to be XXX to win, with previous logic could be XOX or XXO or OOX

**Sample code of problem**
```
if (board[0][0] == 'X' or board[0][0] == 'O') and (board[0][1] == 'X' or board[0][1] == 'O') and (board[0][2] == 'X' or board[0][2] == 'O'):
       print('Congratulations! You won!')
        isWin = True
```

**Sample code of solution**
```
 if ((board[0][0] == 'X') and (board[0][1] == 'X') and (board[0][2] == 'X')) or ((board[0][0] == 'O') and (board[0][1] == 'O') and (board[0][2] == 'O')):
        print('Congratulations! You won! Horizontal win, top row.')
        isWin = True
```

**Solution**
- What you changed
  - Separate X and O by listing X win and then O win
  - Added test_suite() to check all win conditions
