### PR TITLE
Update get_player_move() to turn player_move's datatype from string to array

### DIFF
--- a/devlog.md
+++ b/devlog.md
@@ -135,4 +135,5 @@ a tic-tac-toe game that insults you at every turn. winning does not guarantee ex
 - 5m: Add wesley-blitz to seperate branch
 - 5m: Remember how Python repl and interactive sessions work
 - 10m: Test out get_player_move, update print() to show player's move and return statement
-- 
+- 15m: Learn about combining split() and list comprehension to for player_move in get_player_move()
+- 5m: Add split() and list comprehension to for player_move in get_player_move()

--- a/devlog.md
+++ b/devlog.md
@@ -137,3 +137,4 @@ a tic-tac-toe game that insults you at every turn. winning does not guarantee ex
 - 10m: Test out get_player_move, update print() to show player's move and return statement
 - 15m: Learn about combining split() and list comprehension to for player_move in get_player_move()
 - 5m: Add split() and list comprehension to for player_move in get_player_move()
+- 5m: Test running game, fix error in get_player_move by removing 'value' parameter

--- a/error_logs.md
+++ b/error_logs.md
@@ -24,3 +24,22 @@ def check_win():
     if (board[0][0] = 'X' or 'O') & (board[0][1] = 'X' or 'O') & (board[0][2] = 'X' or 'O'):
 Error: "(" was not closed
 Reason: 
+---
+
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+  File ".\tic-tactless-toe.py", line 44, in get_player_move
+    player_move = int(player_move)
+ValueError: invalid literal for int() with base 10: '1,2
+Reason: Cannot apply int() function to string '1,2' into 1 and 2 intergers.
+int() would work on '54' to 54 intereger, but is thrown off by the comma
+Solution: To remove the comma, we can use split()
+text.split(",")
+Result: ['1','2']
+
+List Comprehension: https://blog.finxter.com/how-to-convert-a-string-list-to-an-integer-list-in-python/#:~:text=The%20most%20Pythonic%20way%20to,x)%20built%2Din%20function.
+
+split() and list comprehension in one line
+text = "1,2"
+new_text = [int(x) for x in text.split(",")]
+print(new_text)

--- a/tic-tactless-toe.py
+++ b/tic-tactless-toe.py
@@ -58,7 +58,7 @@ def update_board(board, player_move, isXTurn):
     # user side: python -c 'import tic-tacless-toe; print tic-tactless-toe.update_board()'
     # python3 -i file_name.py aka python3 -i tic-tactless-toe.py
 
-def is_valid_move(player_move, value):
+def is_valid_move(player_move):
     row = player_move[0]
     column = player_move[1]
     # needs to take input from update_board()
@@ -226,9 +226,9 @@ def test_suite():
     isWin([["O","",""], ["","O", ""], ["","","O"]])
     isWin([["","","O"], ["","O", ""], ["O","",""]])
 
-# start_game()
+start_game()
 # isWin([["X","",""], ["X","", ""], ["X","",""]]) 
-test_suite()
+# test_suite()
 
 
 """

--- a/tic-tactless-toe.py
+++ b/tic-tactless-toe.py
@@ -40,6 +40,10 @@ def get_player_move():
     # TODO make player_move be an array, eg player_move = [2,2] aka bottom right, because input returns a string
     # player_move is used in update_board(), board[player_move[0]][player_move[1]] = "X"
     print(f"This the variable player_move: {player_move}")
+    print(f"This the data type of player_move: {type(player_move)}")
+    player_move = [int(x) for x in player_move.split(",")]
+    print(f"This the variable player_move after int(): {player_move}")
+    print(f"This the data type of player_move after int(): {type(player_move)}")
     return player_move
 
 def update_board(board, player_move, isXTurn):


### PR DESCRIPTION
**Problem**
- Currently, `player_move`'s datatype is a string
- In other functions, such as `is_valid_move(player_move))` `player_move` is an array
  - eg. `row = player_move[0]`
- Thus we need to return `player_move` as an array


**Sample code**
```
def get_player_move():
layer_move = input("Enter your move: row, column\n")
print(f"This the variable player_move: {player_move}")
print(f"This the data type of player_move: {type(player_move)}")
```
Terminal Result
```
>>> get_player_move()
Enter your move: row, column
>>> 1,2 
This the variable player_move: 1,2
This the data type of player_move: <class 'str'>
```

**Solution**
- Add split() and list comprehension to for player_move in get_player_move()
```
player_move = [int(x) for x in player_move.split(",")]
```
  - Remembered split(",") and learnt about list comprehension today